### PR TITLE
Remonte le footer pour qu'il ne soit pas hors de l'écran

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -97,7 +97,6 @@ main {
 
 #foot-text {
   position: absolute;
-  top: 139vh;
 
   padding: 0 5rem;
   text-align: justify;


### PR DESCRIPTION
Je fais cette PR pour ouvrir une discussion. Ne serait-ce pas mieux que le footer soit dans l'écran ?

Je ne suis pas sur de la pertinence de forcer à ce qu'il soit 39% plus bas que le bas de l'écran.

C'est vrai qu'il manque encore les logos et que peut-être les choses seront différentes une fois qu'il auront été ajouté.